### PR TITLE
WP2 -> PASTICHE in logging

### DIFF
--- a/export.py
+++ b/export.py
@@ -106,7 +106,7 @@ def __copy_nc(src, dst):
 def __append_history(src, dst):
     # append history information
     now = datetime.now().astimezone().strftime("%Y-%m-%d %H:%m:%S %Z")
-    history = f"{now} by PaRaMetriC WP2 {VERSION}: export.nc\n"
+    history = f"{now} generated with PASTICHE {VERSION}: export.nc\n"
     history += src.getncattr("history")
     dst.setncattr("history", history)
 

--- a/logger.py
+++ b/logger.py
@@ -29,7 +29,7 @@ import logging
 from logging import debug, info, warning, error
 from datetime import datetime
 
-FMT_MESSAGE = "%(asctime)s [wp2 %(levelname)7s] %(message)s"
+FMT_MESSAGE = "%(asctime)s [PASTICHE %(levelname)7s] %(message)s"
 FMT_DATETIME = "%Y-%m-%d %H:%M:%S"
 
 # Get default logger.
@@ -47,6 +47,6 @@ logger.addHandler(console)
 
 # Logging to file.
 #
-file = logging.FileHandler(datetime.now().strftime("wp2_%Y%m%d-%H%M%S.log"))
+file = logging.FileHandler(datetime.now().strftime("pastiche_%Y%m%d-%H%M%S.log"))
 file.setFormatter(formatter)
 logger.addHandler(file)


### PR DESCRIPTION
we can probably remove legacy references to WP2 now that we have a proper name.

at the moment I found 3 occurrences, see changes below.

BTW, what is the "export.nc" file mentioned in the log string at line 109 of export.py?